### PR TITLE
Centralize Status Badge Configurations and Enhance lift micro-UX

### DIFF
--- a/docs/task.md
+++ b/docs/task.md
@@ -2511,3 +2511,5 @@ Consolidate animation patterns across Radix UI components by centralizing animat
 - [STRENGTHEN] Fixed unused ESLint disable directives and improved type consistency in `packages/api` test files.
 - [STRENGTHEN] Enhanced Language Switcher trigger with a delightful hover rotation/scale micro-UX transition.
 - [CONSOLIDATE] Refactored hardcoded table divider and row hover gray colors in the cluster list table to use the centralized semantic border/muted tokens.
+- [CONSOLIDATE] Extracted hardcoded cluster status configurations from StatusBadge component and centralized them under CLUSTER_STATUS_DETAILS inside @saasfly/common/config/k8s to eliminate duplicates.
+- [STRENGTHEN] Enhanced StatusBadge hover/lift transition to use cohesive y: -1 micro-UX for better delight and visual feedback.

--- a/packages/common/src/config/k8s.ts
+++ b/packages/common/src/config/k8s.ts
@@ -147,3 +147,70 @@ export const K8S_DEFAULTS = {
   network: "Default",
   plan: "FREE" as const,
 } as const;
+
+/**
+ * Detailed information and metadata for each cluster status
+ */
+export const CLUSTER_STATUS_DETAILS: Record<
+  ClusterStatus,
+  {
+    label: string;
+    description: string;
+    variant: "secondary" | "default" | "destructive";
+    bgColor: string;
+    textColor: string;
+    dotColor: string;
+    animate?: boolean;
+  }
+> = {
+  PENDING: {
+    label: "Pending",
+    description: "Cluster creation is queued and waiting to start",
+    variant: "secondary",
+    bgColor: "bg-slate-100 dark:bg-slate-800",
+    textColor: "text-slate-600 dark:text-slate-400",
+    dotColor: "bg-slate-400",
+  },
+  CREATING: {
+    label: "Creating",
+    description: "Cluster infrastructure is being provisioned",
+    variant: "secondary",
+    bgColor: "bg-blue-50 dark:bg-blue-950/30",
+    textColor: "text-blue-600 dark:text-blue-400",
+    dotColor: "bg-blue-500",
+    animate: true,
+  },
+  INITING: {
+    label: "Initializing",
+    description: "Cluster is being configured and services are starting",
+    variant: "secondary",
+    bgColor: "bg-indigo-50 dark:bg-indigo-950/30",
+    textColor: "text-indigo-600 dark:text-indigo-400",
+    dotColor: "bg-indigo-500",
+    animate: true,
+  },
+  RUNNING: {
+    label: "Running",
+    description: "Cluster is operational and ready for workloads",
+    variant: "default",
+    bgColor: "bg-green-50 dark:bg-green-950/30",
+    textColor: "text-green-600 dark:text-green-400",
+    dotColor: "bg-green-500",
+  },
+  STOPPED: {
+    label: "Stopped",
+    description: "Cluster is paused and not consuming resources",
+    variant: "secondary",
+    bgColor: "bg-amber-50 dark:bg-amber-950/30",
+    textColor: "text-amber-600 dark:text-amber-400",
+    dotColor: "bg-amber-500",
+  },
+  DELETED: {
+    label: "Deleted",
+    description: "Cluster has been marked for deletion",
+    variant: "destructive",
+    bgColor: "bg-red-50 dark:bg-red-950/30",
+    textColor: "text-red-600 dark:text-red-400",
+    dotColor: "bg-red-500",
+  },
+};

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -127,6 +127,7 @@ export {
   sanitizeClusterName,
   generateClusterName,
   K8S_DEFAULTS,
+  CLUSTER_STATUS_DETAILS,
 } from "./config/k8s";
 export type {
   ClusterLocation,

--- a/packages/ui/src/status-badge.tsx
+++ b/packages/ui/src/status-badge.tsx
@@ -4,6 +4,7 @@ import { motion } from "framer-motion";
 import {
   BADGE_TOKENS,
   FEEDBACK_TIMING,
+  CLUSTER_STATUS_DETAILS,
   type ClusterStatus,
 } from "@saasfly/common";
 import {
@@ -22,74 +23,13 @@ import {
   TooltipTrigger,
 } from "./tooltip";
 
-interface StatusConfig {
-  icon: typeof Clock;
-  label: string;
-  description: string;
-  variant: "secondary" | "default" | "destructive";
-  bgColor: string;
-  textColor: string;
-  dotColor: string;
-  animate?: boolean;
-}
-
-const statusConfig: Record<ClusterStatus, StatusConfig> = {
-  PENDING: {
-    icon: Clock,
-    label: "Pending",
-    description: "Cluster creation is queued and waiting to start",
-    variant: "secondary",
-    bgColor: "bg-slate-100 dark:bg-slate-800",
-    textColor: "text-slate-600 dark:text-slate-400",
-    dotColor: "bg-slate-400",
-  },
-  CREATING: {
-    icon: SpinnerLoader,
-    label: "Creating",
-    description: "Cluster infrastructure is being provisioned",
-    variant: "secondary",
-    bgColor: "bg-blue-50 dark:bg-blue-950/30",
-    textColor: "text-blue-600 dark:text-blue-400",
-    dotColor: "bg-blue-500",
-    animate: true,
-  },
-  INITING: {
-    icon: SpinnerLoader,
-    label: "Initializing",
-    description: "Cluster is being configured and services are starting",
-    variant: "secondary",
-    bgColor: "bg-indigo-50 dark:bg-indigo-950/30",
-    textColor: "text-indigo-600 dark:text-indigo-400",
-    dotColor: "bg-indigo-500",
-    animate: true,
-  },
-  RUNNING: {
-    icon: Check,
-    label: "Running",
-    description: "Cluster is operational and ready for workloads",
-    variant: "default",
-    bgColor: "bg-green-50 dark:bg-green-950/30",
-    textColor: "text-green-600 dark:text-green-400",
-    dotColor: "bg-green-500",
-  },
-  STOPPED: {
-    icon: PauseCircle,
-    label: "Stopped",
-    description: "Cluster is paused and not consuming resources",
-    variant: "secondary",
-    bgColor: "bg-amber-50 dark:bg-amber-950/30",
-    textColor: "text-amber-600 dark:text-amber-400",
-    dotColor: "bg-amber-500",
-  },
-  DELETED: {
-    icon: XCircle,
-    label: "Deleted",
-    description: "Cluster has been marked for deletion",
-    variant: "destructive",
-    bgColor: "bg-red-50 dark:bg-red-950/30",
-    textColor: "text-red-600 dark:text-red-400",
-    dotColor: "bg-red-500",
-  },
+const statusIcons: Record<ClusterStatus, typeof Clock> = {
+  PENDING: Clock,
+  CREATING: SpinnerLoader,
+  INITING: SpinnerLoader,
+  RUNNING: Check,
+  STOPPED: PauseCircle,
+  DELETED: XCircle,
 };
 
 const sizeStyles = {
@@ -123,16 +63,16 @@ export function StatusBadge({
   className,
   ...props
 }: StatusBadgeProps) {
-  const config = statusConfig[status];
-  const Icon = config.icon;
+  const config = CLUSTER_STATUS_DETAILS[status];
+  const Icon = statusIcons[status] ?? Clock;
   const styles = sizeStyles[size];
 
   const badge = (
     <motion.div
-      whileHover={{ scale: 1.05 }}
-      whileTap={{ scale: 0.95 }}
+      whileHover={{ y: -1, scale: 1.03 }}
+      whileTap={{ scale: 0.98 }}
       className={cn(
-        "inline-flex items-center font-medium transition-colors",
+        "inline-flex items-center font-medium transition-colors cursor-pointer",
         BADGE_TOKENS.radius,
         config.bgColor,
         config.textColor,


### PR DESCRIPTION
This pull request centralizes hardcoded cluster status configurations (colors, text, and labels) from the StatusBadge component into the centralized @saasfly/common package as CLUSTER_STATUS_DETAILS, eliminating duplicate configurations and ensuring decoupled architecture. It also enhances the StatusBadge micro-UX with a cohesive, subtle lift (y: -1) on hover and tap gestures.

---
*PR created automatically by Jules for task [3241456286427311939](https://jules.google.com/task/3241456286427311939) started by @cpa03*