### PR TITLE
Add delightful hover scale micro-interactions to Button and ingest CMZ skills

### DIFF
--- a/.opencode/agent/CMZ/memory.log
+++ b/.opencode/agent/CMZ/memory.log
@@ -24,3 +24,16 @@ Ingested: openx-basefly - ---
 Ingested: planning - ---
 Ingested: proffesor-for-testing-agentic-qe-skill-builder - ---
 Ingested: skill-creator - ---
+--- Self-Learning Cycle Run: Tue Aug  4 00:27:44 UTC 2026 ---
+Ingested: ai-agent-engineer - ---
+Ingested: commit-message - Git commit message automation
+Ingested: debugging - Claude code debugging strategies
+Ingested: github-workflow-automation - ---
+Ingested: maxritter-claude-codepro-backend-models-standards - ---
+Ingested: modu-ai-moai-adk-moai-tool-opencode - ---
+Ingested: muratcankoylan-agent-skills-for-context-engineering-memory-systems - ---
+Ingested: obra-superpowers-systematic-debugging - ---
+Ingested: openx-basefly - ---
+Ingested: planning - ---
+Ingested: proffesor-for-testing-agentic-qe-skill-builder - ---
+Ingested: skill-creator - ---

--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { Loader2 } from "lucide-react";
 
-import { BUTTON_TOKENS } from "@saasfly/common";
+import { BUTTON_TOKENS, UI_ANIMATION } from "@saasfly/common";
 import { cn } from "@saasfly/ui";
 
 import { buttonVariants, type ButtonVariantProps } from "./button-variants";
@@ -123,6 +123,7 @@ const Button = React.memo(
           className={cn(
             buttonVariants({ variant, size, className }),
             BUTTON_TOKENS.activeScale,
+            variant !== "link" && UI_ANIMATION.scale.subtle,
           )}
           ref={ref}
           disabled={isLoading ?? props.disabled}


### PR DESCRIPTION
Implement a tactile, delightful hover scale micro-interaction (hover:scale-[1.02]) on the reusable Button component for non-link variants. This leverages the centralized UI_ANIMATION design tokens to ensure high visual quality and responsiveness. In addition, the CMZ automation specialist agent is audited and updated after running the self-learning ingestion script.

---
*PR created automatically by Jules for task [10908944363117951103](https://jules.google.com/task/10908944363117951103) started by @cpa03*